### PR TITLE
Enable webpack multi bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "license": "ISC",
   "scripts": {
-    "build": "webpack && tsc src/worktime.ts --outDir dist/js && tsc src/background.ts --outDir dist/js",
+    "build": "webpack",
     "prettier": "prettier"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,11 @@
 module.exports = {
-  entry: "./src/index.tsx",
+  entry: {
+    app: "./src/index.tsx",
+    background: "./src/background.ts",
+    worktime: "./src/worktime.ts"
+  },
   output: {
-    filename: "bundle.js",
+    filename: "[name].bundle.js",
     path: __dirname + "/dist/js"
   },
   devtool: "source-map",


### PR DESCRIPTION
## Why

`worktime.ts`, `background.ts` を Webpack でコンパイルするようにして、外部パッケージと一緒にバンドル出来るようにする。